### PR TITLE
Iter21

### DIFF
--- a/.github/workflows/mertricstest.yml
+++ b/.github/workflows/mertricstest.yml
@@ -84,7 +84,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           metricstest -test.v -test.run=^TestIteration1$ \
             -binary-path=cmd/server/server
@@ -115,7 +119,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           metricstest -test.v -test.run=^TestIteration2[AB]*$ \
             -source-path=. \
@@ -141,7 +149,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           metricstest -test.v -test.run=^TestIteration3[AB]*$ \
             -source-path=. \
@@ -167,7 +179,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -196,7 +212,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -224,7 +244,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -251,7 +275,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -277,7 +305,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -302,7 +334,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -327,7 +363,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -351,7 +391,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -374,7 +418,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -396,7 +444,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -417,7 +469,11 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           SERVER_PORT=$(random unused-port)
           ADDRESS="localhost:${SERVER_PORT}"
@@ -439,6 +495,10 @@ jobs:
           github.head_ref == 'iter17' ||
           github.head_ref == 'iter18' ||
           github.head_ref == 'iter19' ||
-          github.head_ref == 'iter20'
+          github.head_ref == 'iter20' ||
+          github.head_ref == 'iter21' ||
+          github.head_ref == 'iter22' ||
+          github.head_ref == 'iter23' ||
+          github.head_ref == 'iter24'
         run: |
           go test -v -race ./...

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ cmd/agent/agent
 cmd/server/main
 cmd/server/server
 cmd/staticlint/multichecker
+cmd/cert/cert
 
 # Dependency directories (remove the comment below to include it)
 vendor/
@@ -34,3 +35,5 @@ cmd/server/metrics.json
 
 # pprof
 profiles
+
+cert/*.cert

--- a/Makefile
+++ b/Makefile
@@ -59,3 +59,7 @@ multichecker:
 build:
 	go build -ldflags "-X main.version=v1.0.1 -X 'main.buildTime=$(date +'%Y/%m/%d %H:%M:%S')'" -o cmd/agent/agent cmd/agent/main.go
 	go build -ldflags "-X main.version=v1.0.1 -X 'main.buildTime=$(date +'%Y/%m/%d %H:%M:%S')'" -o cmd/server/server cmd/server/main.go
+
+certificate:
+	go build -o cmd/cert/cert cmd/cert/main.go
+	cmd/cert/cert

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -43,7 +43,7 @@ func run(loggerZap *zap.SugaredLogger) error {
 	systemRepository := repository.NewSystemRepository()
 
 	serverAddr := "http://" + net.JoinHostPort(configs.NetAddress.Host, configs.NetAddress.Port)
-	client := clients.NewClient(serverAddr, configs.Key, loggerZap)
+	client := clients.NewClient(serverAddr, configs.Key, configs.CryptoKey, loggerZap)
 
 	applicationHandlers := handlers.NewHandlers(
 		client,

--- a/cmd/cert/main.go
+++ b/cmd/cert/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"log"
+	"math/big"
+	"net"
+	"os"
+	"time"
+)
+
+const (
+	serialNumber       = 1658
+	ipv4Address        = 127
+	ipv6Address        = "0:0:0:0:0:0:0:1"
+	certValidity       = 10
+	keySize            = 4096
+	certDir            = "cert"
+	certFile           = "cert/public.cert"
+	privKeyFile        = "cert/private.cert"
+	dirPerm            = 0o750
+	certFilePerm       = 0o600
+	privateKeyFilePerm = 0o600
+)
+
+func main() {
+	// создаём шаблон сертификата
+	cert := &x509.Certificate{
+		// указываем уникальный номер сертификата
+		SerialNumber: big.NewInt(serialNumber),
+		// заполняем базовую информацию о владельце сертификата
+		Subject: pkix.Name{
+			Organization: []string{"Yandex.Praktikum"},
+			Country:      []string{"RU"},
+		},
+		// разрешаем использование сертификата для 127.0.0.1 и ::1
+		IPAddresses: []net.IP{net.IPv4(ipv4Address, 0, 0, 1), net.ParseIP(ipv6Address)},
+		// сертификат верен, начиная со времени создания
+		NotBefore: time.Now(),
+		// время жизни сертификата — 10 лет
+		NotAfter:     time.Now().AddDate(certValidity, 0, 0),
+		SubjectKeyId: []byte{1, 2, 3, 4, 6},
+		// устанавливаем использование ключа для цифровой подписи,
+		// а также клиентской и серверной авторизации
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+	}
+
+	// создаём новый приватный RSA-ключ длиной 4096 бит
+	privateKey, err := rsa.GenerateKey(rand.Reader, keySize)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// создаём сертификат x.509
+	certBytes, err := x509.CreateCertificate(rand.Reader, cert, cert, &privateKey.PublicKey, privateKey)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// кодируем сертификат и ключ в формате PEM, который
+	// используется для хранения и обмена криптографическими ключами
+	var certPEM bytes.Buffer
+	if err := pem.Encode(&certPEM, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certBytes,
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	var privateKeyPEM bytes.Buffer
+	if err := pem.Encode(&privateKeyPEM, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(privateKey),
+	}); err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.MkdirAll(certDir, dirPerm)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.WriteFile(certFile, certPEM.Bytes(), certFilePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = os.WriteFile(privKeyFile, privateKeyPEM.Bytes(), privateKeyFilePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/internal/agent/clients/client.go
+++ b/internal/agent/clients/client.go
@@ -1,7 +1,9 @@
 package clients
 
 import (
+	"crypto/rsa"
 	"fmt"
+	"log"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/go-retryablehttp"
@@ -11,10 +13,11 @@ import (
 type Client struct {
 	RestyClient *resty.Client
 	Logger      *zap.SugaredLogger
+	PublicKey   *rsa.PublicKey
 	Key         string
 }
 
-func NewClient(serverAddr, key string, logger *zap.SugaredLogger) *Client {
+func NewClient(serverAddr, key string, cryptoPath string, logger *zap.SugaredLogger) *Client {
 	handlerLogger := logger.With("agent", "client")
 	retryClient := retryablehttp.NewClient()
 	retryClient.RetryMax = 3
@@ -26,10 +29,20 @@ func NewClient(serverAddr, key string, logger *zap.SugaredLogger) *Client {
 		SetHeader("Content-Encoding", "gzip").
 		SetHeader("Content-Type", "application/json")
 
+	var publicKey *rsa.PublicKey
+	if cryptoPath != "" {
+		var err error
+		publicKey, err = loadRSAPublicKeyFromCert(cryptoPath)
+		if err != nil {
+			log.Fatalf("failed to load public key: %v", err)
+		}
+	}
+
 	client := &Client{
 		RestyClient: restyClient,
 		Logger:      logger,
 		Key:         key,
+		PublicKey:   publicKey,
 	}
 
 	client.RestyClient.OnBeforeRequest(func(c *resty.Client, r *resty.Request) error {
@@ -52,6 +65,13 @@ func (c *Client) processRequest(r *resty.Request) error {
 	if c.Key != "" {
 		hashHex := c.hash(requestBody)
 		r.SetHeader("HashSHA256", hashHex)
+	}
+
+	if c.PublicKey != nil {
+		requestBody, err = c.encrypt(requestBody)
+		if err != nil {
+			return fmt.Errorf("failed to encrypt request body: %w", err)
+		}
 	}
 
 	compressedData, err := c.compress(requestBody)

--- a/internal/agent/clients/client_test.go
+++ b/internal/agent/clients/client_test.go
@@ -15,7 +15,7 @@ func TestNewClient(t *testing.T) {
 	serverAddr := "http://example.com"
 	key := "test-key"
 
-	client := NewClient(serverAddr, key, sugar)
+	client := NewClient(serverAddr, key, "", sugar)
 
 	assert.NotNil(t, client)
 

--- a/internal/agent/clients/encrypt.go
+++ b/internal/agent/clients/encrypt.go
@@ -1,0 +1,19 @@
+package clients
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"errors"
+	"fmt"
+)
+
+func (c *Client) encrypt(data []byte) ([]byte, error) {
+	if c.PublicKey == nil {
+		return nil, errors.New("public key is not loaded")
+	}
+	encryptedData, err := rsa.EncryptPKCS1v15(rand.Reader, c.PublicKey, data)
+	if err != nil {
+		return nil, fmt.Errorf("encryption failed: %w", err)
+	}
+	return encryptedData, nil
+}

--- a/internal/agent/clients/loadCert.go
+++ b/internal/agent/clients/loadCert.go
@@ -1,0 +1,39 @@
+package clients
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+)
+
+// loadRSAPublicKeyFromCert загружает RSA-публичный ключ из сертификата (PEM-формат).
+func loadRSAPublicKeyFromCert(path string) (*rsa.PublicKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read cert file: %w", err)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errors.New("failed to decode PEM block from cert file")
+	}
+
+	if block.Type != "CERTIFICATE" {
+		return nil, fmt.Errorf("expected CERTIFICATE block, got: %s", block.Type)
+	}
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse x509 certificate: %w", err)
+	}
+
+	pubKey, ok := cert.PublicKey.(*rsa.PublicKey)
+	if !ok {
+		return nil, errors.New("certificate does not contain RSA public key")
+	}
+
+	return pubKey, nil
+}

--- a/internal/agent/config/config_test.go
+++ b/internal/agent/config/config_test.go
@@ -7,7 +7,14 @@ import (
 )
 
 func TestProcessFlags(t *testing.T) {
-	cfg, err := processFlags("localhost:8080", 500, 600, "my-secret-key", 10)
+	cfg, err := processFlags(
+		"localhost:8080",
+		500,
+		600,
+		"my-secret-key",
+		10,
+		"test",
+	)
 	assert.NoError(t, err)
 
 	assert.Equal(t, "localhost", cfg.NetAddress.Host)
@@ -18,6 +25,7 @@ func TestProcessFlags(t *testing.T) {
 
 	assert.Equal(t, "my-secret-key", cfg.Key)
 	assert.Equal(t, 10, cfg.RateLimit)
+	assert.Equal(t, "test", cfg.CryptoKey)
 }
 
 func TestParseFlags(t *testing.T) {
@@ -31,4 +39,5 @@ func TestParseFlags(t *testing.T) {
 
 	assert.Equal(t, "", cfg.Key)
 	assert.Equal(t, 1, cfg.RateLimit)
+	assert.Equal(t, "", cfg.CryptoKey)
 }

--- a/internal/server/config/config.go
+++ b/internal/server/config/config.go
@@ -51,6 +51,12 @@ const (
 	descriptionKey = "Agent adds a HashSHA256 header with the computed hash"
 )
 
+const (
+	flagCryptoKey        = "crypto-key"
+	envCryptoKey         = "CRYPTO_KEY"
+	cryptoKeyDescription = "Cryptographic encryption key"
+)
+
 type Config struct {
 	// Ключ для вычисления хеша.
 	Key        string
@@ -59,6 +65,8 @@ type Config struct {
 	FileStoragePath string
 	// Настройки БД в формате dsn.
 	DatabaseDsn string
+	// Включить поддержку асимметричного шифрования
+	CryptoKey string
 	// Интервал сохранения хранилища.
 	StoreInterval int
 	// Разрешить загрузку из файла хранилища.
@@ -79,6 +87,7 @@ func ParseFlags() (*Config, error) {
 	restoreFlag := flag.Bool(flagRestore, defaultRestore, descriptionRestore)
 	addressDatabaseFlag := flag.String(flagDatabaseDSN, defaultDatabaseDSN, descriptionDatabaseDSN)
 	keyFlag := flag.String(flagKey, defaultKey, descriptionKey)
+	cryptoFlag := flag.String(flagCryptoKey, "", cryptoKeyDescription)
 	enablePprof := flag.Bool("pprof", false, "enable pprof for debugging")
 
 	flag.Parse()
@@ -95,6 +104,7 @@ func ParseFlags() (*Config, error) {
 		*restoreFlag,
 		*addressDatabaseFlag,
 		*keyFlag,
+		*cryptoFlag,
 		*enablePprof,
 	)
 }
@@ -106,6 +116,7 @@ func processFlags(
 	restoreFlag bool,
 	addressDatabaseFlag string,
 	keyFlag string,
+	cryptoKeyFlag string,
 	enablePprof bool,
 ) (*Config, error) {
 	finalAddress, err := getStringValue(addressFlag, envHTTPAddress)
@@ -143,6 +154,11 @@ func processFlags(
 		key = ""
 	}
 
+	cryptoKey, err := getStringValue(cryptoKeyFlag, envCryptoKey)
+	if err != nil {
+		cryptoKey = ""
+	}
+
 	return &Config{
 		NetAddress:      NetAddress{Host: host, Port: port},
 		StoreInterval:   storeInterval,
@@ -151,6 +167,7 @@ func processFlags(
 		Restore:         restore,
 		Key:             key,
 		Debug:           enablePprof,
+		CryptoKey:       cryptoKey,
 	}, nil
 }
 

--- a/internal/server/config/config_test.go
+++ b/internal/server/config/config_test.go
@@ -14,6 +14,7 @@ func TestParseAddressFlags(t *testing.T) {
 		true,
 		"postgres://user:pass@localhost:5432/dbname",
 		"my-secret-key",
+		"test",
 		true,
 	)
 	assert.NoError(t, err)
@@ -29,6 +30,8 @@ func TestParseAddressFlags(t *testing.T) {
 
 	assert.Equal(t, "postgres://user:pass@localhost:5432/dbname", cfg.DatabaseDsn)
 	assert.Equal(t, "my-secret-key", cfg.Key)
+
+	assert.Equal(t, "test", cfg.CryptoKey)
 
 	assert.Equal(t, true, cfg.Debug)
 }
@@ -47,6 +50,8 @@ func TestParseFlags(t *testing.T) {
 
 	assert.Equal(t, "", cfg.DatabaseDsn)
 	assert.Equal(t, "", cfg.Key)
+
+	assert.Equal(t, "", cfg.CryptoKey)
 
 	assert.Equal(t, false, cfg.Debug)
 }

--- a/internal/server/middleware/decrypt.go
+++ b/internal/server/middleware/decrypt.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"io"
+	"net/http"
+	"strconv"
+)
+
+func DecryptMiddleware(privateKey *rsa.PrivateKey) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if privateKey == nil {
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			encryptedData, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, "failed to read request body", http.StatusBadRequest)
+				return
+			}
+			defer func(Body io.ReadCloser) {
+				_ = Body.Close()
+			}(r.Body)
+
+			decryptedData, err := rsa.DecryptPKCS1v15(rand.Reader, privateKey, encryptedData)
+			if err != nil {
+				http.Error(w, "failed to decrypt request body", http.StatusBadRequest)
+				return
+			}
+
+			r.Body = io.NopCloser(bytes.NewReader(decryptedData))
+			r.ContentLength = int64(len(decryptedData))
+			r.Header.Set("Content-Length", strconv.Itoa(len(decryptedData)))
+			r.Header.Set("Content-Type", "application/json")
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/server/router/loadCert.go
+++ b/internal/server/router/loadCert.go
@@ -1,0 +1,28 @@
+package router
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+)
+
+func loadRSAPrivateKeyFromFile(path string) (*rsa.PrivateKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read key file: %w", err)
+	}
+
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "RSA PRIVATE KEY" {
+		return nil, fmt.Errorf("invalid PEM block or type: %v", block.Type)
+	}
+
+	key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse private key: %w", err)
+	}
+
+	return key, nil
+}


### PR DESCRIPTION
Добавьте в агент и сервер поддержку асимметричного шифрования. 

1. Для агента: с помощью флага -crypto-key или переменной окружения CRYPTO_KEY передайте путь до файла с публичным ключом.

2. Для сервера: с помощью флага -crypto-key или переменной окружения CRYPTO_KEY передайте путь до файла с приватным ключом.

3. Шифруйте сообщения от агента к серверу с помощью ключей.

