### PR TITLE
Iter24

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ server_config
   "store_interval": "1s", // аналог переменной окружения STORE_INTERVAL или флага -i
   "store_file": "/path/to/file.db", // аналог переменной окружения STORE_FILE или -f
   "database_dsn": "", // аналог переменной окружения DATABASE_DSN или флага -d
-  "crypto_key": "/path/to/key.pem" // аналог переменной окружения CRYPTO_KEY или флага -crypto-key
+  "crypto_key": "/path/to/key.pem", // аналог переменной окружения CRYPTO_KEY или флага -crypto-key
+  "trusted_subnet" : "" // CIDR
 } 
 ```

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"net"
+)
+
 type AgentConfig struct {
 	// Ключ для вычисления хеша.
 	Key string `json:"-"`
@@ -18,6 +22,9 @@ type AgentConfig struct {
 }
 
 type ServerConfig struct {
+	TrustedNet *net.IPNet `json:"-"`
+	// CIDR
+	TrustedSubnet string `json:"trusted_subnet,omitempty"`
 	// Ключ для вычисления хеша.
 	Key string `json:"-"`
 	// Адрес сервера.

--- a/internal/config/server/server_config_test.go
+++ b/internal/config/server/server_config_test.go
@@ -18,6 +18,7 @@ func TestParseAddressFlags(t *testing.T) {
 		true,
 		"",
 		"",
+		"",
 	)
 	assert.NoError(t, err)
 

--- a/internal/middleware/check_trusted_subnet_middleware.go
+++ b/internal/middleware/check_trusted_subnet_middleware.go
@@ -1,0 +1,37 @@
+package middleware
+
+import (
+	"net"
+	"net/http"
+
+	"go.uber.org/zap"
+)
+
+func CheckTrustedSubnetMiddleware(
+	logger *zap.SugaredLogger,
+	trustedSubnet *net.IPNet,
+) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if trustedSubnet == nil {
+			return next
+		}
+
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			realIP := r.Header.Get("X-Real-IP")
+			ip := net.ParseIP(realIP)
+			if ip == nil {
+				logger.Infow("invalid or missing X-Real-IP", "ip", realIP)
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+
+			if !trustedSubnet.Contains(ip) {
+				logger.Infow("unauthorized IP", "ip", ip.String())
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -33,6 +33,7 @@ func ConfigureServerHandler(
 		middleware2.CheckHashMiddleware(logger, cfg.Key),
 		middleware2.ResponseHashMiddleware(cfg.Key),
 		middleware2.ResponseCompressionMiddleware(logger),
+		middleware2.CheckTrustedSubnetMiddleware(logger, cfg.TrustedNet),
 	)
 
 	register(router, cfg, memStorage, logger)


### PR DESCRIPTION
Добавьте в конфигурационный JSON-файл сервера поле trusted_subnet (тип string, переменная окружения TRUSTED_SUBNET, флаг -t), в которое можно передать строковое представление бесклассовой адресации (CIDR).
Добавьте в запрос агента заголовок X-Real-IP, в котором должен содержаться IP-адрес хоста агента.
При отправке метрик агентом серверу нужно проверять, что переданный в заголовке запроса X-Real-IP IP-адрес агента входит в доверенную подсеть, в противном случае возвращать статус ответа 403 Forbidden.
При пустом значении переменной trusted_subnet метрики должны обрабатываться сервером без дополнительных ограничений.